### PR TITLE
README, namespace correction, file management

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Tool for verifying Calico Enterprise installation and configuration
  sudo mv kubectl-calicocheck /usr/local/bin/
  ```
 
+## How to run
+
+```
+kubectl-calicocheck | tee execution-summary
+```
 
 ### Checks performed
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tool for verifying Calico Enterprise installation and configuration
 
 ## How to run
 
+
 ```
 kubectl-calicocheck | tee execution-summary
 ```


### PR DESCRIPTION
Changeset :
1. README update -  To run calicocheck with execution summary 
2. kube-apiserver check removed as "kube-apiserver" is not available to user in most cases except when installed with "kubeadm"
3. Did basic file management/deletion
4. fixed the logic for namespaces as discussed