### PR TITLE
Adding update_calicocheck.sh and fix the asked changes in calico-cluster-check.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ check_tier
 calico_diagnostics
 display_summary
 ```
+
+### Script available to update the local calico-confg-check script
+
+## How to run
+
+```
+chmod +x update_calicocheck.sh
+./update_calicocheck.sh
+```

--- a/update_calicocheck.sh
+++ b/update_calicocheck.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+git fetch origin >/dev/null 2>&1
+git rev-parse --remotes >/dev/null 2>&1
+
+UPSTREAM=${1:-'@{u}'}
+LOCAL=$(git rev-parse @)
+REMOTE=$(git rev-parse "$UPSTREAM")
+BASE=$(git merge-base @ "$UPSTREAM")
+
+if [ $LOCAL = $REMOTE ]; then
+    echo "Up-to-date"
+elif [ $LOCAL = $BASE ]; then
+    echo "Need to pull"
+    read -p "Do you want to update the calico-check script?(yes/no)" reply
+    case $reply in 
+	    [Yy]es) echo "Updating the script file ....."
+		    git pull origin master >/dev/null 2>&1 && echo "Update successfull";;
+	    [Nn]o) echo "No download done" ;;
+	        *) echo "Wrong answer. Print yes or no"
+		   unset reply ;;
+    esac
+fi


### PR DESCRIPTION
1. Added the update_calicocheck.sh script
2. Appended code to copy the latest tmp.* directory content to diagnostics directory. Also printed the absolute path of this directory.
3. Check for Calico Enterprise and Calico has been added, which runs different sets of checks.

Note: Separate functions need to be added for checking the api-server and calico_pod status on Calico cluster.